### PR TITLE
CI: Trigger linter during CI Builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: node_js
+script:
+  - npm run verify


### PR DESCRIPTION
### Description

Previously CI builds only ran the test suite. After this PR, the linter will also run in addition to the test suite to find any format issues before PRs are allowed to be merged into main branch.